### PR TITLE
Andymck/fix serverside compat with chatterbox

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,9 @@
                deprecated_function_calls, deprecated_functions]}.
 
 {project_plugins, [covertool,
-                   {grpcbox_plugin, "~> 0.7.0"},
+                   {grpcbox_plugin,
+                    {git, "https://github.com/andymck/grpcbox_plugin.git",
+                        {branch, "andymck/server-support-for-continue-response"}}},
                    rebar3_lint]}.
 
 {cover_enabled, true}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,13 +1,13 @@
 {erl_opts, [debug_info]}.
 
-{deps, [{chatterbox, {pkg, ts_chatterbox}},
+{deps, [{chatterbox, {git, "https://github.com/joedevivo/chatterbox.git", {branch, "master"}}},
         ctx,
         acceptor_pool,
         gproc]}.
 
 {grpc, [{protos, ["proto"]},
-        {service_modules, [{'grpc.health.v1.Health', "grpcbox_health"},
-                           {'grpc.reflection.v1alpha.ServerReflection', "grpcbox_reflection"}]},
+        {service_modules, [{'grpc.health.v2.Health', "grpcbox_health"},
+                           {'grpc.reflection.v2alpha.ServerReflection', "grpcbox_reflection"}]},
         {gpb_opts, [{descriptor, true},
                     {module_name_prefix, "grpcbox_"},
                     {module_name_suffix, "_pb"}]}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -6,8 +6,8 @@
         gproc]}.
 
 {grpc, [{protos, ["proto"]},
-        {service_modules, [{'grpc.health.v2.Health', "grpcbox_health"},
-                           {'grpc.reflection.v2alpha.ServerReflection', "grpcbox_reflection"}]},
+        {service_modules, [{'grpc.health.v1.Health', "grpcbox_health"},
+                           {'grpc.reflection.v1alpha.ServerReflection', "grpcbox_reflection"}]},
         {gpb_opts, [{descriptor, true},
                     {module_name_prefix, "grpcbox_"},
                     {module_name_suffix, "_pb"}]}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,13 +1,15 @@
 {"1.1.0",
 [{<<"acceptor_pool">>,{pkg,<<"acceptor_pool">>,<<"1.0.0">>},0},
- {<<"chatterbox">>,{pkg,<<"ts_chatterbox">>,<<"0.9.1">>},0},
+ {<<"chatterbox">>,
+  {git,"https://github.com/joedevivo/chatterbox.git",
+       {ref,"560f2c71a151716512781f0f6196a8a9ff678852"}},
+  0},
  {<<"ctx">>,{pkg,<<"ctx">>,<<"0.5.0">>},0},
  {<<"gproc">>,{pkg,<<"gproc">>,<<"0.8.0">>},0},
  {<<"hpack">>,{pkg,<<"hpack_erl">>,<<"0.2.3">>},1}]}.
 [
 {pkg_hash,[
  {<<"acceptor_pool">>, <<"43C20D2ACAE35F0C2BCD64F9D2BDE267E459F0F3FD23DAB26485BF518C281B21">>},
- {<<"chatterbox">>, <<"843557EE729B04B3C1BDAC33FB162DAEFDBF4F7AE0AF0BDC055FB16E91E057E3">>},
  {<<"ctx">>, <<"78E0F16712E12D707A7F34277381B8E193D7C71EAA24D37330DC02477C09EDA5">>},
  {<<"gproc">>, <<"CEA02C578589C61E5341FCE149EA36CCEF236CC2ECAC8691FBA408E7EA77EC2F">>},
  {<<"hpack">>, <<"17670F83FF984AE6CD74B1C456EDDE906D27FF013740EE4D9EFAA4F1BF999633">>}]}

--- a/src/grpcbox_services_sup.erl
+++ b/src/grpcbox_services_sup.erl
@@ -128,6 +128,7 @@ load_services([], _, _) ->
 load_services([ServicePbModule | Rest], Services, ServicesTable) ->
     ServiceNames = ServicePbModule:get_service_names(),
     [begin
+         %% NOTE: Methods value may be a map or a prop depending on gpb options when generating the services
          {{service, _}, Methods} = ServicePbModule:get_service_def(ServiceName),
          %% throws exception if ServiceName isn't in the map or doesn't exist
          try
@@ -140,7 +141,7 @@ load_services([ServicePbModule | Rest], Services, ServicesTable) ->
                         output := Output,
                         input_stream := InputStream,
                         output_stream := OutputStream,
-                        opts := Opts} = maps:from_list(P),
+                        opts := Opts} = ensure_map(P),
                       SnakedMethodName = atom_snake_case(Name),
                       case lists:member({SnakedMethodName, 2}, Exports) of
                           true ->
@@ -181,3 +182,8 @@ atom_snake_case(Name) ->
     Snaked1 = string:replace(Snaked, ".", "_", all),
     Snaked2 = string:replace(Snaked1, "__", "_", all),
     list_to_atom(string:to_lower(unicode:characters_to_list(Snaked2))).
+
+ensure_map(S) when is_map(S)->
+    S;
+ensure_map(S) when is_list(S)->
+    maps:from_list(S).

--- a/src/grpcbox_services_sup.erl
+++ b/src/grpcbox_services_sup.erl
@@ -130,10 +130,17 @@ load_services([ServicePbModule | Rest], Services, ServicesTable) ->
     [begin
          {{service, _}, Methods} = ServicePbModule:get_service_def(ServiceName),
          %% throws exception if ServiceName isn't in the map or doesn't exist
-         try ServiceModule = maps:get(ServiceName, Services),
+         try
+             ServiceModule = maps:get(ServiceName, Services),
               {ServiceModule, ServiceModule:module_info(exports)} of
              {ServiceModule1, Exports} ->
                  [begin
+                      #{name := Name,
+                        input := Input,
+                        output := Output,
+                        input_stream := InputStream,
+                        output_stream := OutputStream,
+                        opts := Opts} = maps:from_list(P),
                       SnakedMethodName = atom_snake_case(Name),
                       case lists:member({SnakedMethodName, 2}, Exports) of
                           true ->
@@ -149,12 +156,7 @@ load_services([ServicePbModule | Rest], Services, ServicesTable) ->
                               %% TODO: error? log? insert into ets as unimplemented?
                               unimplemented_method
                       end
-                  end || #{name := Name,
-                           input := Input,
-                           output := Output,
-                           input_stream := InputStream,
-                           output_stream := OutputStream,
-                           opts := Opts} <- Methods]
+                  end || P <- Methods]
          catch
              _:_ ->
                  %% TODO: error? log? insert into ets as unimplemented?

--- a/src/grpcbox_stream.erl
+++ b/src/grpcbox_stream.erl
@@ -79,17 +79,16 @@
 }.
 -type grpc_extended_error_response() :: {grpc_extended_error, grpc_error_data()}.
 
--spec stream_handler_state(t()) -> t().
+-spec stream_handler_state(t()) -> any().
 stream_handler_state(#state{stream_handler_state = StreamHandlerState}) ->
     StreamHandlerState.
--spec stream_handler_state(t(), any()) -> t().
+-spec stream_handler_state(t(), any()) -> any().
 stream_handler_state(State, NewStreamHandlerState) ->
     State#state{stream_handler_state = NewStreamHandlerState}.
 
--spec stream_req_headers(t()) -> t().
+-spec stream_req_headers(t()) -> list().
 stream_req_headers(#state{req_headers = ReqHeaders}) ->
     ReqHeaders.
-
 
 init(ConnPid, StreamId, [Socket, ServicesTable, AuthFun, UnaryInterceptor,
                          StreamInterceptor, StatsHandler]) ->

--- a/src/grpcbox_stream.erl
+++ b/src/grpcbox_stream.erl
@@ -16,6 +16,7 @@
          error/2,
          ctx/1,
          ctx/2,
+         end_stream/1,
          handle_streams/2,
          handle_call/2,
          handle_info/2]).

--- a/src/grpcbox_stream.erl
+++ b/src/grpcbox_stream.erl
@@ -107,7 +107,6 @@ init(ConnPid, StreamId, [Socket, ServicesTable, AuthFun, UnaryInterceptor,
     {ok, State}.
 
 on_receive_request_headers(Headers, State=#state{ctx=_Ctx}) ->
-    %% proplists:get_value(<<":method">>, Headers) =:= <<"POST">>,
     Metadata = grpcbox_utils:headers_to_metadata(Headers),
     Ctx = case parse_options(<<"grpc-timeout">>, Headers) of
                infinity ->
@@ -160,13 +159,12 @@ handle_auth(_Ctx, State=#state{auth_fun=AuthFun,
         {true, _Identity} ->
             case InputStreaming of
                 true ->
+                    %% TODO - Revisit this, consider scenario where both input and output streaming
+                    %%        make sure not blocking each other
                     Ref = make_ref(),
-                    Pid = proc_lib:spawn_link(?MODULE, handle_streams,
-                                              [Ref, State#state{handler=self()}]),
-                    {ok, State#state{input_ref=Ref,
-                                     callback_pid=Pid}};
+                    State0 = maybe_init_handler_state(Module, State),
+                    {ok, State0#state{input_ref=Ref}};
                 _ ->
-                    %% maybe initialize server side handler state
                     State0 = maybe_init_handler_state(Module, State),
                     {ok, State0}
             end;
@@ -195,8 +193,10 @@ handle_streams(Ref, State=#state{full_method=FullMethod,
                                  output_stream => false},
                   StreamInterceptor(Ref, State, ServerInfo, fun Module:Function/2)
           end) of
-        {ok, Response, State2} ->
-            send(Response, State2);
+        ok ->
+            end_stream(?GRPC_STATUS_OK, <<"">>, State);
+        {continue, NewState} ->
+            NewState;
         E={grpc_error, _} ->
             throw(E);
         E={grpc_extended_error, _} ->
@@ -259,9 +259,9 @@ on_receive_request_data(Bin, State=#state{request_encoding=Encoding,
             end_stream(?GRPC_STATUS_UNKNOWN, <<>>, State)
     end.
 
-handle_message(EncodedMessage, State=#state{input_ref=Ref,
+handle_message(EncodedMessage, State=#state{input_ref=_Ref,
                                             ctx=Ctx,
-                                            callback_pid=Pid,
+                                            callback_pid=_Pid,
                                             method=#method{proto=Proto,
                                                            input={Input, InputStream},
                                                            output={_Output, OutputStream}}}) ->
@@ -272,8 +272,7 @@ handle_message(EncodedMessage, State=#state{input_ref=Ref,
                                                  compressed_size => size(EncodedMessage)}, State),
             case {InputStream, OutputStream} of
                 {true, _} ->
-                    Pid ! {Ref, Message},
-                    State1;
+                    handle_streams(Message, State1#state{handler=self()});
                 {false, true} ->
                     handle_streams(Message, State1#state{handler=self()});
                 {false, false} ->


### PR DESCRIPTION
This PR brings grpcbox up to date with current chatterbox and adds support for a number of additional features which should make for more flexible and deeper integration of grpcbox at the application level.

1.  Update server side functionality to use current version of chatterbox and current h2 stream callbacks

2. Easier support long running application callback handlers when dealing with streaming connections.  Handlers can return the 'continue' directive and in doing so grpcbox will keep the stream active rather than assume the handler is done and terminate

3. Allow info messages to be threaded from stream to application callback handlers.  Allows applications to route messages to application callback handlers when utilising long running handlers
  
4.  Allow application callback handlers to define & maintain their own state within the context of the grpcbox stream.   Pass state with all calls to application handler callbacks.
